### PR TITLE
Fix: Correct typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Simple CRUD views:
 ### How to use coveralls.io
 
 - enable your GitHub repo on https://coveralls.io/
-- `gem instanll travis`
+- `gem install travis`
 - `travis encrypt COVERALLS_REPO_TOKEN={your token} -add -r {github user}/{github repo}`
 
 ### Skinny Framework


### PR DESCRIPTION
Hey, our tool caught a few typos in your repository.

Also, a few typos on your site like 'questsions'. Here is your error report:
 https://triplechecker.com/s/fPRC1T/skinny-framework.github.io

Hope it's helpful!
